### PR TITLE
Add simple auth with login/register

### DIFF
--- a/servicios-app/src/App.jsx
+++ b/servicios-app/src/App.jsx
@@ -1,9 +1,13 @@
+/* global process */
 import { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button.jsx'
 import { Input } from '@/components/ui/input.jsx'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { Badge } from '@/components/ui/badge.jsx'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.jsx'
+import LoginTabs from './LoginTabs.jsx'
+import Profile from './Profile.jsx'
+import { useUser } from './UserContext.jsx'
 import { 
   Search, 
   Home, 
@@ -24,6 +28,7 @@ import {
 import './App.css'
 
 function App() {
+  const { user } = useUser()
   const [currentView, setCurrentView] = useState('home')
   const [selectedCategory, setSelectedCategory] = useState('')
   const [selectedProfessional, setSelectedProfessional] = useState(null)
@@ -119,6 +124,16 @@ function App() {
     } else if (currentView === 'professionals') {
       setCurrentView('home')
       fetchFeaturedProfessionals() // Refresh featured professionals
+    } else if (currentView === 'login' || currentView === 'user-profile') {
+      setCurrentView('home')
+    }
+  }
+
+  const handlePerfilClick = () => {
+    if (user) {
+      setCurrentView('user-profile')
+    } else {
+      setCurrentView('login')
     }
   }
 
@@ -211,7 +226,7 @@ function App() {
             <Clock className="w-6 h-6" />
             <span className="text-xs">Historial</span>
           </Button>
-          <Button variant="ghost" className="flex flex-col items-center space-y-1 text-gray-600">
+          <Button variant="ghost" className="flex flex-col items-center space-y-1 text-gray-600" onClick={handlePerfilClick}>
             <User className="w-6 h-6" />
             <span className="text-xs">Perfil</span>
           </Button>
@@ -290,7 +305,7 @@ function App() {
               <Clock className="w-6 h-6" />
               <span className="text-xs">Historial</span>
             </Button>
-            <Button variant="ghost" className="flex flex-col items-center space-y-1 text-gray-600">
+            <Button variant="ghost" className="flex flex-col items-center space-y-1 text-gray-600" onClick={handlePerfilClick}>
               <User className="w-6 h-6" />
               <span className="text-xs">Perfil</span>
             </Button>
@@ -429,7 +444,7 @@ function App() {
               <Clock className="w-6 h-6" />
               <span className="text-xs">Historial</span>
             </Button>
-            <Button variant="ghost" className="flex flex-col items-center space-y-1 text-gray-600">
+            <Button variant="ghost" className="flex flex-col items-center space-y-1 text-gray-600" onClick={handlePerfilClick}>
               <User className="w-6 h-6" />
               <span className="text-xs">Perfil</span>
             </Button>
@@ -444,6 +459,8 @@ function App() {
       {currentView === 'home' && renderHome()}
       {currentView === 'professionals' && renderProfessionals()}
       {currentView === 'profile' && renderProfile()}
+      {currentView === 'login' && <LoginTabs onSuccess={() => setCurrentView('user-profile')} />}
+      {currentView === 'user-profile' && <Profile />}
     </div>
   )
 }

--- a/servicios-app/src/LoginTabs.jsx
+++ b/servicios-app/src/LoginTabs.jsx
@@ -1,0 +1,72 @@
+/* global process */
+import { useState } from 'react'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs.jsx'
+import { Input } from '@/components/ui/input.jsx'
+import { Button } from '@/components/ui/button.jsx'
+import { useUser } from './UserContext.jsx'
+
+function LoginTabs({ onSuccess }) {
+  const { setUser } = useUser()
+  const API_URL = process.env.REACT_APP_API_URL || '/api'
+
+  const [loginData, setLoginData] = useState({ username: '', password: '' })
+  const [registerData, setRegisterData] = useState({ username: '', email: '', password: '' })
+
+  const handleChange = (setter) => (e) => {
+    setter((prev) => ({ ...prev, [e.target.name]: e.target.value }))
+  }
+
+  const handleLogin = async (e) => {
+    e.preventDefault()
+    const res = await fetch(`${API_URL}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(loginData)
+    })
+    if (res.ok) {
+      const data = await res.json()
+      setUser(data.user)
+      onSuccess && onSuccess()
+    }
+  }
+
+  const handleRegister = async (e) => {
+    e.preventDefault()
+    const res = await fetch(`${API_URL}/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(registerData)
+    })
+    if (res.ok) {
+      const data = await res.json()
+      setUser(data.user)
+      onSuccess && onSuccess()
+    }
+  }
+
+  return (
+    <Tabs defaultValue="login" className="p-4 space-y-4">
+      <TabsList className="grid w-full grid-cols-2">
+        <TabsTrigger value="login">Iniciar sesión</TabsTrigger>
+        <TabsTrigger value="register">Registrarse</TabsTrigger>
+      </TabsList>
+      <TabsContent value="login">
+        <form onSubmit={handleLogin} className="space-y-3 mt-4">
+          <Input name="username" placeholder="Usuario" value={loginData.username} onChange={handleChange(setLoginData)} />
+          <Input type="password" name="password" placeholder="Contraseña" value={loginData.password} onChange={handleChange(setLoginData)} />
+          <Button type="submit" className="w-full">Entrar</Button>
+        </form>
+      </TabsContent>
+      <TabsContent value="register">
+        <form onSubmit={handleRegister} className="space-y-3 mt-4">
+          <Input name="username" placeholder="Usuario" value={registerData.username} onChange={handleChange(setRegisterData)} />
+          <Input name="email" type="email" placeholder="Email" value={registerData.email} onChange={handleChange(setRegisterData)} />
+          <Input type="password" name="password" placeholder="Contraseña" value={registerData.password} onChange={handleChange(setRegisterData)} />
+          <Button type="submit" className="w-full">Crear cuenta</Button>
+        </form>
+      </TabsContent>
+    </Tabs>
+  )
+}
+
+export default LoginTabs

--- a/servicios-app/src/Profile.jsx
+++ b/servicios-app/src/Profile.jsx
@@ -1,0 +1,19 @@
+import { useUser } from './UserContext.jsx'
+
+function Profile() {
+  const { user } = useUser()
+
+  if (!user) {
+    return <div className="p-4">No hay usuario autenticado.</div>
+  }
+
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-xl font-semibold">Perfil</h1>
+      <p>Usuario: {user.username}</p>
+      <p>Email: {user.email}</p>
+    </div>
+  )
+}
+
+export default Profile

--- a/servicios-app/src/UserContext.jsx
+++ b/servicios-app/src/UserContext.jsx
@@ -1,0 +1,16 @@
+import { createContext, useContext, useState } from 'react'
+
+const UserContext = createContext(null)
+
+export function UserProvider({ children }) {
+  const [user, setUser] = useState(null)
+  return (
+    <UserContext.Provider value={{ user, setUser }}>
+      {children}
+    </UserContext.Provider>
+  )
+}
+
+export function useUser() {
+  return useContext(UserContext)
+}

--- a/servicios-app/src/main.jsx
+++ b/servicios-app/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { UserProvider } from './UserContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <UserProvider>
+      <App />
+    </UserProvider>
   </StrictMode>,
 )

--- a/servicios-app/vite.config.js
+++ b/servicios-app/vite.config.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'

--- a/servicios-backend/src/main.py
+++ b/servicios-backend/src/main.py
@@ -13,6 +13,7 @@ from src.routes.user import user_bp
 from src.routes.professional import professional_bp
 from src.routes.service_request import service_request_bp
 from src.routes.review import review_bp
+from src.routes.auth import auth_bp
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'change-me')
@@ -25,6 +26,7 @@ app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(professional_bp, url_prefix='/api')
 app.register_blueprint(service_request_bp, url_prefix='/api')
 app.register_blueprint(review_bp, url_prefix='/api')
+app.register_blueprint(auth_bp, url_prefix='/api')
 
 # Database configuration
 app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv(

--- a/servicios-backend/src/models/user.py
+++ b/servicios-backend/src/models/user.py
@@ -1,4 +1,5 @@
 from flask_sqlalchemy import SQLAlchemy
+from werkzeug.security import generate_password_hash, check_password_hash
 
 db = SQLAlchemy()
 
@@ -6,9 +7,16 @@ class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128))
 
     def __repr__(self):
         return f'<User {self.username}>'
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
 
     def to_dict(self):
         return {

--- a/servicios-backend/src/routes/auth.py
+++ b/servicios-backend/src/routes/auth.py
@@ -1,0 +1,31 @@
+from flask import Blueprint, jsonify, request
+from src.models.user import User, db
+from werkzeug.security import generate_password_hash, check_password_hash
+import secrets
+
+auth_bp = Blueprint('auth', __name__)
+
+@auth_bp.route('/register', methods=['POST'])
+def register():
+    data = request.json
+    if not all(k in data for k in ('username', 'email', 'password')):
+        return jsonify({'error': 'Missing fields'}), 400
+    if User.query.filter_by(username=data['username']).first():
+        return jsonify({'error': 'User exists'}), 400
+    user = User(username=data['username'], email=data['email'])
+    user.set_password(data['password'])
+    db.session.add(user)
+    db.session.commit()
+    token = secrets.token_hex(16)
+    return jsonify({'token': token, 'user': user.to_dict()}), 201
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    data = request.json
+    if not all(k in data for k in ('username', 'password')):
+        return jsonify({'error': 'Missing fields'}), 400
+    user = User.query.filter_by(username=data['username']).first()
+    if user and user.check_password(data['password']):
+        token = secrets.token_hex(16)
+        return jsonify({'token': token, 'user': user.to_dict()})
+    return jsonify({'error': 'Invalid credentials'}), 401


### PR DESCRIPTION
## Summary
- add auth blueprint with /login and /register
- store hashed passwords on users
- create LoginTabs, Profile page and user context
- update App to show login/profile views

## Testing
- `npm run lint`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68722b2f81c0832094ee8ddf55eee247